### PR TITLE
an open path now stay open

### DIFF
--- a/format/svg/SVGRenderer.hx
+++ b/format/svg/SVGRenderer.hx
@@ -149,8 +149,13 @@ class SVGRenderer
        for(segment in inPath.segments)
           segment.toGfx(mGfx, context);
 
+
+       // endFill automatically close an open path
+       // by putting endLineStyle before endFill, the closing line is not drawn
+       // so an open path in inkscape stay open in openfl
+       // this does not affect closed path
+       mGfx.endLineStyle(); 
        mGfx.endFill();
-       mGfx.endLineStyle();
     }
 
 


### PR DESCRIPTION
The following image was made in Inkscape:
![image](https://cloud.githubusercontent.com/assets/12205892/7480331/ec291a34-f335-11e4-8ee2-758412892d7e.png)

The current version of openfl/svg close open paths when rendering:
![screenshot from 2015-05-05 14 22 52](https://cloud.githubusercontent.com/assets/12205892/7480385/3990a5bc-f336-11e4-90fb-10085ff7afbc.png)

This pull request fixes this issue as you can see in the following image:
![screenshot from 2015-05-05 14 20 21](https://cloud.githubusercontent.com/assets/12205892/7480422/66e689fa-f336-11e4-9191-10a3d09aa094.png)
