### PR TITLE
Update SVGRenderer.hx line thickness scale fix

### DIFF
--- a/format/svg/SVGRenderer.hx
+++ b/format/svg/SVGRenderer.hx
@@ -134,7 +134,7 @@ class SVGRenderer
           else
           {
              var style = new format.gfx.LineStyle();
-             var scale = Math.sqrt(m.a*m.a + m.c*m.c);
+             var scale = Math.sqrt(m.a*m.a + m.d*m.d);
              style.thickness = inPath.stroke_width*scale;
              style.alpha = inPath.stroke_alpha*inPath.alpha;
              style.color = inPath.stroke_colour;


### PR DESCRIPTION
Line thickness previously only scaled correctly on X axis values. The Matrix being used to scale was using properties a and c (for X) instead of a and d (X/Y). Fixed.

Note, scaling thickness only works 'well' if scaling equally across both axes. Lines can be any orientation so thickness can't scale in only certain dimensions. As a best practice, it is likely ideal to always convert lines to actual shapes before using them with this library.