### PR TITLE
Don't render hidden elements

### DIFF
--- a/format/svg/SVGData.hx
+++ b/format/svg/SVGData.hx
@@ -538,6 +538,8 @@ class SVGData extends Group {
 				
 			}
 
+			if (el.exists("display") && el.get("display") == "none") continue;
+
 			if (name == "defs") {
 				
 				loadDefs (el);

--- a/test/SvgGenerationTest.hx
+++ b/test/SvgGenerationTest.hx
@@ -103,6 +103,13 @@ class SvgGenerationTest
         generateAndCompareWithLayerFilter("layer_test2.svg", "red", "nested_layer.svg", "red");
     }
 
+    @Test
+    public function disabledLayers()
+    {
+        generateAndCompareWithLayerFilter("layer_test1.svg", null, "disabled_test1.svg", null);
+        generateAndCompareWithLayerFilter("layer_test1.svg", null, "disabled_test2.svg", null);
+    }
+
     @BeforeClass
     public function cleanPreviousTestRunResults() {
         

--- a/test/images/disabled_test1.svg
+++ b/test/images/disabled_test1.svg
@@ -1,0 +1,4 @@
+<svg id="svg1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+  <rect x="10" y="10" width="100" height="20" style="fill:#f00;stroke:#000;stroke-width:10;" transform="scale(2.0)"/>
+  <g id="blue" display="none"><rect x="30" y="25" width="40" height="20" style="fill:#0f0;stroke:#000;stroke-width:15;" transform="matrix(3.38073983743877, 0.905868727550796, -0.905868727550796, 3.38073983743877, 0, 0)"/></g>
+</svg>

--- a/test/images/disabled_test2.svg
+++ b/test/images/disabled_test2.svg
@@ -1,0 +1,4 @@
+<svg id="svg1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+  <rect x="10" y="10" width="100" height="20" style="fill:#f00;stroke:#000;stroke-width:10;" transform="scale(2.0)"/>
+  <g id="blue"><rect display="none" x="30" y="25" width="40" height="20" style="fill:#0f0;stroke:#000;stroke-width:15;" transform="matrix(3.38073983743877, 0.905868727550796, -0.905868727550796, 3.38073983743877, 0, 0)"/></g>
+</svg>


### PR DESCRIPTION
Checks if an element has the `display="none"` flag set and ignores it.

Includes 2 tests unified in 1 : 
- first test checks if a hidden group is not rendered ( this worked before )
- second test checks if a hidden element is not rendered ( new )

Closes #55 
