### PR TITLE
Use `openfl` instead of `flash` packages

### DIFF
--- a/format/SVG.hx
+++ b/format/SVG.hx
@@ -1,9 +1,9 @@
 package format;
 
 
-import flash.display.Graphics;
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
+import openfl.display.Graphics;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
 import format.svg.SVGData;
 import format.svg.SVGRenderer;
 

--- a/format/gfx/Gfx.hx
+++ b/format/gfx/Gfx.hx
@@ -1,14 +1,14 @@
 package format.gfx;
 
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
 import format.svg.Text;
 
-import flash.geom.Matrix;
+import openfl.geom.Matrix;
 
 class Gfx
 {

--- a/format/gfx/Gfx2Haxe.hx
+++ b/format/gfx/Gfx2Haxe.hx
@@ -1,12 +1,12 @@
 package format.gfx;
 
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
-import flash.geom.Matrix;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
+import openfl.geom.Matrix;
 
 
 class Gfx2Haxe extends Gfx

--- a/format/gfx/GfxBytes.hx
+++ b/format/gfx/GfxBytes.hx
@@ -1,14 +1,14 @@
 package format.gfx;
 
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
-import flash.geom.Matrix;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
+import openfl.geom.Matrix;
 
-import flash.utils.ByteArray;
+import openfl.utils.ByteArray;
 
 import haxe.io.Bytes;
 

--- a/format/gfx/GfxExtent.hx
+++ b/format/gfx/GfxExtent.hx
@@ -1,7 +1,7 @@
 package format.gfx;
 
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
 
 class GfxExtent extends Gfx
 {

--- a/format/gfx/GfxGraphics.hx
+++ b/format/gfx/GfxGraphics.hx
@@ -1,14 +1,14 @@
 package format.gfx;
 
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
-import flash.display.Graphics;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
+import openfl.display.Graphics;
 
-import flash.geom.Matrix;
+import openfl.geom.Matrix;
 
 class GfxGraphics extends Gfx
 {

--- a/format/gfx/Gradient.hx
+++ b/format/gfx/Gradient.hx
@@ -1,12 +1,12 @@
 package format.gfx;
 
-import flash.geom.Matrix;
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
+import openfl.geom.Matrix;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
 
 class Gradient
 {

--- a/format/gfx/LineStyle.hx
+++ b/format/gfx/LineStyle.hx
@@ -1,8 +1,8 @@
 package format.gfx;
 
-import flash.display.LineScaleMode;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
+import openfl.display.LineScaleMode;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
 
 class LineStyle
 {

--- a/format/svg/BitmapDataManager.hx
+++ b/format/svg/BitmapDataManager.hx
@@ -3,10 +3,10 @@ package format.svg;
 //import gm2d.reso.Resources;
 import format.svg.SVGRenderer;
 
-import flash.geom.Matrix;
-import flash.display.Shape;
-import flash.display.Bitmap;
-import flash.display.BitmapData;
+import openfl.geom.Matrix;
+import openfl.display.Shape;
+import openfl.display.Bitmap;
+import openfl.display.BitmapData;
 
 
 class BitmapDataManager
@@ -37,9 +37,9 @@ class BitmapDataManager
       var h = Std.int(svg.height*inScale +  0.99);
       var bmp = new BitmapData(w,h,true,0x00);
       var q = gm2d.Lib.current.stage.quality;
-      flash.Lib.current.stage.quality = flash.display.StageQuality.BEST;
+      openfl.Lib.current.stage.quality = flash.display.StageQuality.BEST;
       bmp.draw(shape,matrix);
-      flash.Lib.current.stage.quality = q;
+      openfl.Lib.current.stage.quality = q;
 
       if (inCache)
          bitmaps.set(key,bmp);

--- a/format/svg/Grad.hx
+++ b/format/svg/Grad.hx
@@ -1,14 +1,14 @@
 package format.svg;
 
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
 
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
 
 class Grad extends /*gm2d.gfx.Gradient*/format.gfx.Gradient
 {

--- a/format/svg/Gradient.hx
+++ b/format/svg/Gradient.hx
@@ -1,12 +1,12 @@
 package format.svg;
 
-import flash.geom.Matrix;
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
+import openfl.geom.Matrix;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
 
 class Gradient
 {

--- a/format/svg/Path.hx
+++ b/format/svg/Path.hx
@@ -1,12 +1,12 @@
 package format.svg;
 
-import flash.geom.Matrix;
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
+import openfl.geom.Matrix;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
 
 typedef PathSegments = Array<PathSegment>;
 

--- a/format/svg/PathSegment.hx
+++ b/format/svg/PathSegment.hx
@@ -1,8 +1,8 @@
 package format.svg;
-import flash.geom.Rectangle;
-import flash.geom.Matrix;
-import flash.geom.Point;
-import flash.display.Graphics;
+import openfl.geom.Rectangle;
+import openfl.geom.Matrix;
+import openfl.geom.Point;
+import openfl.display.Graphics;
 import format.gfx.Gfx;
 
 class PathSegment

--- a/format/svg/RenderContext.hx
+++ b/format/svg/RenderContext.hx
@@ -1,7 +1,7 @@
 package format.svg;
 
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
 
 class RenderContext
 {

--- a/format/svg/SVGData.hx
+++ b/format/svg/SVGData.hx
@@ -1,12 +1,12 @@
 package format.svg;
 
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
-import flash.display.GradientType;
-import flash.display.Graphics;
-import flash.display.SpreadMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
+import openfl.display.GradientType;
+import openfl.display.Graphics;
+import openfl.display.SpreadMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
 import format.svg.Grad;
 import format.svg.Group;
 import format.svg.FillType;

--- a/format/svg/SVGRenderer.hx
+++ b/format/svg/SVGRenderer.hx
@@ -3,25 +3,25 @@ package format.svg;
 import format.svg.PathParser;
 import format.svg.PathSegment;
 
-import flash.geom.Matrix;
-import flash.geom.Rectangle;
-import flash.display.Graphics;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
+import openfl.display.Graphics;
 
-import flash.display.Shape;
-import flash.display.Sprite;
-import flash.display.DisplayObject;
-import flash.display.GradientType;
-import flash.display.SpreadMethod;
-import flash.display.InterpolationMethod;
-import flash.display.CapsStyle;
-import flash.display.JointStyle;
-import flash.display.LineScaleMode;
+import openfl.display.Shape;
+import openfl.display.Sprite;
+import openfl.display.DisplayObject;
+import openfl.display.GradientType;
+import openfl.display.SpreadMethod;
+import openfl.display.InterpolationMethod;
+import openfl.display.CapsStyle;
+import openfl.display.JointStyle;
+import openfl.display.LineScaleMode;
 
 import format.svg.Grad;
 import format.svg.Group;
 import format.svg.FillType;
 import format.gfx.Gfx;
-import flash.geom.Rectangle;
+import openfl.geom.Rectangle;
 
 
 typedef GroupPath = Array<String>;
@@ -318,9 +318,9 @@ class SVGRenderer
        var w = Std.int(Math.ceil( inRect==null ? width : inRect.width*inScale ));
        var h = Std.int(Math.ceil( inRect==null ? width : inRect.height*inScale ));
 
-       var bmp = new flash.display.BitmapData(w,h,true,#if (neko && !haxe3) { a: 0x00, rgb: 0x000000 } #else 0x00000000 #end);
+       var bmp = new openfl.display.BitmapData(w,h,true,#if (neko && !haxe3) { a: 0x00, rgb: 0x000000 } #else 0x00000000 #end);
 
-       var shape = new flash.display.Shape();
+       var shape = new openfl.display.Shape();
        mGfx = new format.gfx.GfxGraphics(shape.graphics);
 
        mGroupPath = [];

--- a/format/svg/Text.hx
+++ b/format/svg/Text.hx
@@ -1,6 +1,6 @@
 package format.svg;
 
-import flash.geom.Matrix;
+import openfl.geom.Matrix;
 
 
 class Text

--- a/test/MacroTest.hx
+++ b/test/MacroTest.hx
@@ -1,0 +1,24 @@
+package;
+
+import massive.munit.Assert;
+
+import format.SVG;
+
+/**
+* Tests that using SVGs inside macros actually compiles. If the `flash` package
+* is used instead of the `openfl` package.
+*/
+class MacroTest
+{
+	macro static function makeSvg()
+	{
+		// This macro will fail if the `flash` package is used.
+		return macro new SVG("<svg></svg>");
+	}
+
+	@Test
+	public function compilesInMacro()
+	{
+		Assert.isNotNull(makeSvg());
+	}
+}

--- a/test/TestSuite.hx
+++ b/test/TestSuite.hx
@@ -1,6 +1,7 @@
 import massive.munit.TestSuite;
 
 import SvgGenerationTest;
+import MacroTest;
 
 /**
  * Auto generated Test Suite for MassiveUnit.
@@ -15,5 +16,6 @@ class TestSuite extends massive.munit.TestSuite
 		super();
 
 		add(SvgGenerationTest);
+		add(MacroTest);
 	}
 }


### PR DESCRIPTION
Fixes compilation errors when this library is used from a macro somewhere. This patch simply replaces the uses of the `flash` package with `openfl`.

To reproduce the error, `git checkout 2f6e46ba7a9fee71e11cd771f74af748684eee6e` and try to run the tests. They should fail to compile with:

```
HaxeWrapper.hx:73: format/SVG.hx:4: characters 7-29 : You cannot access the
flash package while in a macro (for flash.display.Graphics)
```

This would resolve #57.