### PR TITLE
Fix Cairo crash caused by rgb() def in stop-color

### DIFF
--- a/format/svg/SVGData.hx
+++ b/format/svg/SVGData.hx
@@ -195,6 +195,12 @@ class SVGData extends Group {
 			return parseHex(s.substr(1));
 			
 		}
+				
+		if (mRGBMatch.match (s)) {
+			
+			return parseRGBMatch(mRGBMatch);
+			
+		}
 		
 		return Std.parseInt (s);
 		


### PR DESCRIPTION
Cairo (neko platform) was crashing on create gradient from stop-color definitions in rgb(r, g, b) format. Added a check in getColorStyle to use the existing rgb parse function. Crash no longer occurs.