### PR TITLE
Fixes group styles contamination among siblings.

### DIFF
--- a/format/svg/SVGData.hx
+++ b/format/svg/SVGData.hx
@@ -359,30 +359,21 @@ class SVGData extends Group {
 	
 	
 	private function getStyles (inNode:Xml, inPrevStyles:StringMap<String>):StringMap <String> {
-		
-		if (!inNode.exists ("style"))
-			return inPrevStyles;
 
-		var styles = new StringMap <String> ();
-		
-		if (inPrevStyles != null) {
-			
-			for (s in inPrevStyles.keys ()) {
-				
-				styles.set (s, inPrevStyles.get (s));
-			
-			}
-			
-		}
+		var styles = inPrevStyles != null ? inPrevStyles.copy() : new StringMap <String> ();
 
-		var style = inNode.get ("style");
-		var strings = mStyleSplit.split (style);
-		
-		for (s in strings) {
-		
-			if (mStyleValue.match (s)) {
-				
-				styles.set (mStyleValue.matched (1), mStyleValue.matched (2));
+		if (inNode.exists ("style")) {
+
+			var style = inNode.get ("style");
+			var strings = mStyleSplit.split (style);
+			
+			for (s in strings) {
+			
+				if (mStyleValue.match (s)) {
+					
+					styles.set (mStyleValue.matched (1), mStyleValue.matched (2));
+					
+				}
 				
 			}
 			


### PR DESCRIPTION
Fix for group style contamination among siblings.

Before (Notice the strange lines + unusual thickness):
<img width="979" height="940" alt="chrome_K1CWWTagxz" src="https://github.com/user-attachments/assets/73996ac2-ac0d-42ee-bdb2-f20100368754" />

After:
<img width="915" height="940" alt="chrome_kpM0mnex4B" src="https://github.com/user-attachments/assets/091803d9-b8ca-4e67-81a2-d636553b1fd6" />
